### PR TITLE
Quick changes and code cleanup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,34 +1,33 @@
-use rand::prelude::*;
-use std::{thread::sleep, time::Duration};
+use rand::{seq::SliceRandom, thread_rng, Rng};
+use std::{process, thread::sleep, time::Duration};
 
 fn main() {
     
     let m: i8 = 60; // Default time in minutes to wait between each URL Request
     let uri = vec!["CONTRIBUTING.md", "CodeQL.yml", "LICENSE.txt", "README.md", "SECURITY.md", "cglicenses.json", "cgmanifest.json", "gulpfile.js", "package.json", "product.json"];
-    let uri_len = uri.len() - 1;
-    let mut r_uri: usize = thread_rng().gen_range(1,uri_len); // random uri selector
     let mut x: i8 = 0; // count the number of itteration to the loop
     let mut y: i8 = thread_rng().gen_range(1,11); // Number of loop to do before changing the URI
     let fqdn = "https://github.com/microsoft/vscode/".to_string().to_owned(); // Domain we use for our C2 config
-    let mut url = fqdn.clone() + uri.get(r_uri).unwrap(); // Full URL where to grab the C2 instructions
+    let mut url = fqdn.clone() + uri.choose(&mut rand::thread_rng()).unwrap(); // Full URL where to grab the C2 instructions
 
     loop {
-
         let jit: f32 = thread_rng().gen_range(0.0,2.0);
         let ttw8: u64 = (m as f32 * 60.0 * jit) as u64; // Time to wait in minutes
-        let minutes = Duration::from_secs(ttw8.try_into().unwrap());
+        let minutes = Duration::from_secs(ttw8.into());
 
         println!("Minutes to wait: {} URL to Fetch: {}", ttw8/60, url);
         sleep(minutes);
-        reqwest::blocking::get(url.clone()).expect("request failed");
+        if reqwest::blocking::get(url.clone()).is_err()  {
+            println!("Request failed. Unable to get {url}");
+            process::exit(1);
+        }
+
         x+=1;
 
         if x == y {
             y = thread_rng().gen_range(1,11);
             x = 0;
-            r_uri = thread_rng().gen_range(0, uri_len);
-            //println!("R_URI: {r_uri}");
-            url = fqdn.clone() + uri.get(r_uri).unwrap();
+            url = fqdn.clone() + uri.choose(&mut rand::thread_rng()).unwrap();
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,31 +3,27 @@ use std::{process, thread::sleep, time::Duration};
 
 fn main() {
     
-    let m: i8 = 60; // Default time in minutes to wait between each URL Request
+    let m = 60; // Default time in minutes to wait between each URL Request
     let uri = vec!["CONTRIBUTING.md", "CodeQL.yml", "LICENSE.txt", "README.md", "SECURITY.md", "cglicenses.json", "cgmanifest.json", "gulpfile.js", "package.json", "product.json"];
-    let mut x: i8 = 0; // count the number of itteration to the loop
-    let mut y: i8 = thread_rng().gen_range(1,11); // Number of loop to do before changing the URI
+    let mut y; // Number of loop to do before changing the URI
     let fqdn = "https://github.com/microsoft/vscode/".to_string().to_owned(); // Domain we use for our C2 config
-    let mut url = fqdn.clone() + uri.choose(&mut rand::thread_rng()).unwrap(); // Full URL where to grab the C2 instructions
+    let mut url; // Full URL where to grab the C2 instructions
 
     loop {
-        let jit: f32 = thread_rng().gen_range(0.0,2.0);
-        let ttw8: u64 = (m as f32 * 60.0 * jit) as u64; // Time to wait in minutes
-        let minutes = Duration::from_secs(ttw8.into());
+        y = thread_rng().gen_range(1,11);
+        url = fqdn.clone() + uri.choose(&mut rand::thread_rng()).unwrap();
 
-        println!("Minutes to wait: {} URL to Fetch: {}", ttw8/60, url);
-        sleep(minutes);
-        if reqwest::blocking::get(url.clone()).is_err()  {
-            println!("Request failed. Unable to get {url}");
-            process::exit(1);
-        }
+        for _ in 0 .. y {
+            let jit: f32 = thread_rng().gen_range(0.0,2.0);
+            let ttw8: u64 = (m as f32 * 60.0 * jit) as u64; // Time to wait in minutes
+            let minutes = Duration::from_secs(ttw8.into());
 
-        x+=1;
-
-        if x == y {
-            y = thread_rng().gen_range(1,11);
-            x = 0;
-            url = fqdn.clone() + uri.choose(&mut rand::thread_rng()).unwrap();
+            println!("Minutes to wait: {} URL to Fetch: {}", ttw8/60, url);
+            sleep(minutes);
+            if reqwest::blocking::get(url.clone()).is_err()  {
+                println!("Request failed. Unable to get {url}");
+                process::exit(1);
+            }
         }
     }
 }


### PR DESCRIPTION
* Gracefully handle a failure to get an HTTP resource
* Use `rand::choose()` instead of using slice indices

Note that choose() can still fail if the slice it's called on is empty. Because the vector they're called on is changed only at compile time, both are safe to unwrap if the application is tested to pick each of the options. Typically using the direct index in a vector or slice is considered a no-no (anit-pattern) in Rust.